### PR TITLE
Add clean URLs

### DIFF
--- a/src/app/models/grants.js
+++ b/src/app/models/grants.js
@@ -3,7 +3,8 @@ var $ = require('jquery'),
     _ = require('lodash'),
     numeral = require('numeral'),
     moment = require('moment'),
-    settings = require('../settings');
+    settings = require('../settings'),
+    util = require('../util');
 
 var Grants = {};
 
@@ -28,6 +29,9 @@ Grants.Model = Backbone.Model.extend({
     if (data && data.field_end_date) {
       data.end_date = moment(data.field_end_date, settings.api.dateFormat).format("YYYY");
     }
+
+    data.field_funder.slug = util.slugify(data.field_funder.name);
+    data.field_recipient.slug = util.slugify(data.field_recipient.name);
 
     data.created = moment.unix(data.created).format("YYYY");
     data.changed = moment.unix(data.changed).format("MMMM D YYYY");

--- a/src/app/models/ntees.js
+++ b/src/app/models/ntees.js
@@ -3,7 +3,8 @@ var $ = require('jquery'),
     _ = require('lodash'),
     numeral = require('numeral'),
     moment = require('moment'),
-    settings = require('../settings');
+    settings = require('../settings'),
+    util = require('../util');
 
 var Ntee = {};
 
@@ -12,8 +13,9 @@ Ntee.Model = Backbone.Model.extend({
     return settings.api.baseurl + '/ntees/' + this.id + '.jsonp/?callback=?';
   },
 
+
   parse: function(response) {
-    data = response.data;
+    var data = response.data;
     data.orgs = response.included;
 
     // Format dates
@@ -26,6 +28,8 @@ Ntee.Model = Backbone.Model.extend({
     // Format dollar amounts nicely
     data.totals.received_pretty = numeral(data.totals.received).format('0,0[.]00');
     data.totals.funded_pretty = numeral(data.totals.funded).format('0,0[.]00');
+
+    data.slug = util.slugify(data.name);
 
     return data;
   }

--- a/src/app/models/organizations.js
+++ b/src/app/models/organizations.js
@@ -1,7 +1,8 @@
 var Backbone = require('backbone'),
     _ = require('lodash'),
     numeral = require('numeral'),
-    settings = require('../settings');
+    settings = require('../settings'),
+    util = require('../util');
 
 var Organizations = {};
 
@@ -17,6 +18,14 @@ Organizations.Model = Backbone.Model.extend({
     }
     if (data && data.org_grants_received) {
       data.amount_received = numeral(data.org_grants_received).format('0,0[.]00');
+    }
+
+    data.slug = util.slugify(data.title);
+
+    if (data.field_ntee) {
+      _.each(data.field_ntee.und, function(ntee) {
+        ntee.slug = util.slugify(ntee.name);
+      });
     }
 
     return data;

--- a/src/app/router.js
+++ b/src/app/router.js
@@ -17,12 +17,14 @@ var AppRouter = Backbone.Router.extend({
     '': 'home',
     '!/quality': 'showQuality',
 
-    '!/organizations/:id': 'showOrganization',
+    '!/organizations/:id(/)': 'showOrganization',
+    '!/organizations/:id/:slug(/)': 'showOrganization',
     '!/organizations(/)': 'showOrganizations',
 
     '!/grants/:id': 'showGrant',
 
     '!/ntee/:id': 'showNtee',
+    '!/ntee/:id/:slug': 'showNtee',
 
     '!/:id': 'showPage',
 

--- a/src/app/templates/grants/item.html
+++ b/src/app/templates/grants/item.html
@@ -9,7 +9,7 @@
         <div class="col-md-6">
             From
             <h2>
-                <a href="#!/organizations/<%= grant.field_funder.target_id %>">
+                <a href="#!/organizations/<%= grant.field_funder.target_id %>/<%= grant.field_funder.slug %>">
                     <%= grant.field_funder.name %>
                 </a>
             </h2>
@@ -17,7 +17,7 @@
         <div class="col-md-6">
             To
             <h2>
-                <a href="#!/organizations/<%= grant.field_recipient.target_id %>">
+                <a href="#!/organizations/<%= grant.field_recipient.target_id %>/<%= grant.field_recipient.slug %>">
                     <%= grant.field_recipient.name %>
                 </a>
             </h2>

--- a/src/app/templates/grants/list.html
+++ b/src/app/templates/grants/list.html
@@ -15,7 +15,7 @@
         <% _.each(organizations, function(organization) { %>
             <tr class="organization">
                 <td class="name">
-                    <a href="#!/organizations/<%= organization.id %>">
+                    <a href="#!/organizations/<%= organization.id %>/<%= organization.slug %>">
                         <strong><%- organization.name %></strong>
                     </a>
                 </td>
@@ -54,5 +54,5 @@
     </table>
 <% } %>
 </div>
-   
+
 

--- a/src/app/templates/organizations/item.html
+++ b/src/app/templates/organizations/item.html
@@ -5,7 +5,7 @@
       <% if (o.field_ntee) { %>
         <div class="tags">
         <% _.each(o.field_ntee.und, function(ntee) { %>
-            <a href="#!/ntee/<%= ntee.tid %>" class="tag"><%= ntee.name %></a>
+            <a href="#!/ntee/<%= ntee.tid %>/<%= ntee.slug %>" class="tag"><%= ntee.name %></a>
         <% }); %>
         </div>
       <% } %>

--- a/src/app/templates/organizations/list.html
+++ b/src/app/templates/organizations/list.html
@@ -1,7 +1,7 @@
 <% if (organizations.length > 0) { %>
 <% _.each(organizations, function(o) { %>
 <div class="org">
-    <h2><a href="#!/organizations/<%= o.id %>"><%= o.title %></a></h2>
+    <h2><a href="#!/organizations/<%= o.id %>/<%= o.slug %>"><%= o.title %></a></h2>
 
     <p>
     <% if (o.amount_funded) { %>

--- a/src/app/templates/organizations/ol.html
+++ b/src/app/templates/organizations/ol.html
@@ -1,5 +1,5 @@
 <ol>
 <% _.each(organizations, function(o) { %>
-  <li><a href="#!/organizations/<%= o.id %>"><%= o.title %></a> ($<%= o[key].toLocaleString() %>)</li>
+  <li><a href="#!/organizations/<%= o.id %>/<%= o.slug %>"><%= o.title %></a> ($<%= o[key].toLocaleString() %>)</li>
 <% }); %>
 </ol>

--- a/src/app/util.js
+++ b/src/app/util.js
@@ -1,0 +1,13 @@
+var util = {
+  slugify: function(text) {
+    return text.toString().toLowerCase()
+      .replace(/\s+/g, '-')           // Replace spaces with -
+      .replace(/\/+/g, '-')           // Replace slashes with -
+      .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
+      .replace(/\-\-+/g, '-')         // Replace multiple - with single -
+      .replace(/^-+/, '')             // Trim - from start of text
+      .replace(/-+$/, '');            // Trim - from end of text
+  }
+};
+
+module.exports = util;

--- a/src/app/views/grants/list.js
+++ b/src/app/views/grants/list.js
@@ -11,7 +11,14 @@ var GrantListView = Backbone.View.extend({
 
   template: template,
 
-  /**
+  /**console.log('Loading a web page');
+var page = require('webpage').create();
+var url = 'http://phantomjs.org/';
+page.open(url, function (status) {
+  //Page is loaded!
+  phantom.exit();
+});
+
    * Initialize the grant list
    * @param  {Object} options
    *                  options.direction: required. Specifies which grants to

--- a/src/app/views/grants/list.js
+++ b/src/app/views/grants/list.js
@@ -4,7 +4,8 @@ var $ = require('jquery'),
     Backbone = require('backbone'),
     numeral = require('numeral'),
     Grants = require('../../models/grants'),
-    template = require('../../templates/grants/list.html');
+    template = require('../../templates/grants/list.html'),
+    util = require('../../util');
 
 var GrantListView = Backbone.View.extend({
 
@@ -25,7 +26,7 @@ var GrantListView = Backbone.View.extend({
       render();
       _this.afterRender();
       return _this;
-    })
+    });
 
     this.direction = options.direction;
 
@@ -115,6 +116,7 @@ var GrantListView = Backbone.View.extend({
         prettySum: numeral(sum).format('0,0[.]00'),
         id: organziation_id,
         name: group_names_by_id[organziation_id],
+        slug: util.slugify(group_names_by_id[organziation_id]),
         grants: grants
       });
     });


### PR DESCRIPTION
Tack on an optional slug to URLs to make them more human and seo-friendly. All old URLs still work -- only the node ID is used to resolve the page. 

Example: 

`/#!/ntee/288/` becomes `/#!/ntee/288/food-service-free-food-distribution-programs`

`/#!/organizations/226/` becomes `/#!/organizations/226/forgotten-harvest-inc`

`/#!/organizations/226/forgotten-harvest-inc` works the same as `/#!/organizations/226/the-ledger-team-is-awesome`
